### PR TITLE
Fixes

### DIFF
--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -9,9 +9,21 @@ DynamicCache:
   optInHeader: null
 # If a header should be used to explicitly disable caching for a cache, set the
 # regular expression here which will be used to match the specified header
-  optOutHeader: '/(^X\-DynamicCache\-OptOut)|(^Location)/'
+  optOutHeader: '/(^X\-DynamicCache\-OptOut)/'
 # Header to use by the module attempting to opt out
   optOutHeaderString: 'X-DynamicCache-OptOut: true'
+# Status codes that should be cached
+  optInResponseCodes:
+    - 200
+    - 203
+    - 204
+    - 205
+    - 300
+    - 301
+    - 404
+    - 410
+# Status codes that should not be cached (overrides optInResponseCodes)
+  optOutResponseCodes: null
 # Header prefix to use for reporting cache results
   responseHeader: 'X-DynamicCache'
 # If caching should be limited only to specified urls set the regular expression
@@ -31,7 +43,7 @@ DynamicCache:
 # Determines which headers should also be cached. X-Include-CSS and other relevant
 # headers can be essential in instructing the front end to include specific
 # resource files
-  cacheHeaders: '/^(X\-)|(Cache\-Control)|(Etag)|(Expires)|(Last\-Modified)/i'
+  cacheHeaders: '/^(X\-)|(Cache\-Control)|(Etag)|(Expires)|(Last\-Modified)|(Location)/i'
 # If you wish to override the cache configuration, then change this to another 
 # backend, and initialise a new SS_Cache backend in your _config file
   cacheBackend: 'DynamicCache' 

--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -49,5 +49,4 @@ DynamicCache:
   cacheBackend: 'DynamicCache' 
 # Specify page types to skip caching for
   ignoredPages:
-    - ErrorPage
     - UserDefinedForm

--- a/code/DynamicCache.php
+++ b/code/DynamicCache.php
@@ -168,8 +168,7 @@ class DynamicCache extends Object {
 		}
 
 		// Segment by url
-		$url = trim($url, '/');
-		$fragments[] = $url ? $url : 'home';
+		$fragments[] = trim($url, '/');
 
 		// Extend
 		$this->extend('updateCacheKeyFragments', $fragments);


### PR DESCRIPTION
**Work in progress**

* Fixed /home/ not redirecting to root. This happened because 'home' was being used as the URL component of the cache key for root, which tricked system in to thinking /home/' was a valid URL.
* Fixed status codes not being cached. This was because `headers_list()` [does not report the status code header](http://us2.php.net/manual/en/function.headers-list.php#110330) as it is a [special case](https://bugs.php.net/bug.php?id=52555).
* Added sensible caching defaults, including caching of 301 redirects and 404 responses

The reason this is a WIP is that it uses `http_response_code()` function which is only available from PHP 5.4 onwards. Assuming you are happy with these changes, would you prefer this went in to:

a) 3.1 branch, with composer.json and README.md requirements updated with PHP 5.4 requirement
b) A new major version due to PHP 5.4 requirement

?