### PR TITLE
Cache Content-Type

### DIFF
--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -43,7 +43,7 @@ DynamicCache:
 # Determines which headers should also be cached. X-Include-CSS and other relevant
 # headers can be essential in instructing the front end to include specific
 # resource files
-  cacheHeaders: '/^(X\-)|(Cache\-Control)|(Etag)|(Expires)|(Last\-Modified)|(Location)/i'
+  cacheHeaders: '/^(X\-)|(Content\-Type)|(Cache\-Control)|(Etag)|(Expires)|(Last\-Modified)|(Location)/i'
 # If you wish to override the cache configuration, then change this to another 
 # backend, and initialise a new SS_Cache backend in your _config file
   cacheBackend: 'DynamicCache' 


### PR DESCRIPTION
Content-Type should also be cached & used by default else all cached content automatically gets a `text/html; charset=utf-8` header. An example of this is a site map which should have `application/xml; charset="utf-8"`, or a cached json response with `application/json`