### PR TITLE
Allow cacheDir config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ See [dynamiccache.yml](_config/dynamiccache.yml) for the list of configurable op
    content for different hostname, but still uses the same backend, such as the
    subsites module
  * enableAjax - (boolean) Determine if caching should be enabled during ajax
+ * cacheDir - (string) Directory where file-based caches are stored 
+   (either absolute, or relative to TEMP_FOLDER).
+   Allows usage of %BASE_PATH% and %ASSETS_PATH% placeholders.
+   Please ensure that the folder is either located outside of the webroot, or appropriately secured.
  * cacheDuration - (null|integer) Duration of the page cache, in seconds (default is 1 hour).
  * cacheHeaders - (null|string) Determines which headers should also be cached.
    X-Include-CSS and other relevant headers can be essential in instructing the

--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -38,6 +38,10 @@ DynamicCache:
   segmentHostname: true
 # Determine if caching should be enabled during ajax
   enableAjax: false
+# Directory where file-based caches are stored (either absolute, or relative to TEMP_FOLDER)
+# Allows usage of %BASE_PATH% and %ASSETS_PATH% placeholders.
+# Please ensure that the folder is either located outside of the webroot, or appropriately secured.
+  cacheDir: 'dynamic_cache'
 # Duration of the page cache, in seconds
   cacheDuration: 3600
 # Determines which headers should also be cached. X-Include-CSS and other relevant

--- a/code/DynamicCache.php
+++ b/code/DynamicCache.php
@@ -160,8 +160,24 @@ class DynamicCache extends Object
         // Create default backend if not overridden
         if ($backend === 'DynamicCache') {
 
+            $cacheDir = str_replace(
+                array(
+                    '%BASE_PATH%',
+                    '%ASSETS_PATH%'
+                ),
+                array(
+                    BASE_PATH,
+                    ASSETS_PATH
+                ),
+                self::config()->cacheDir
+            );
+
             // Using own folder helps with separating page cache from other SS cached elements
-            $cacheDir = TEMP_FOLDER . DIRECTORY_SEPARATOR . 'dynamic_cache';
+            // TODO Use Filesystem::isAbsolute() once $_ENV['OS'] bug is fixed (should use getenv())
+            if ($cacheDir[0] !== '/') {
+                $cacheDir = TEMP_FOLDER . DIRECTORY_SEPARATOR . $cacheDir;
+            }
+
             if (!is_dir($cacheDir)) {
                 mkdir($cacheDir);
             }


### PR DESCRIPTION
Needed for multi-server installations with a NFS shared filesystem - you can make it work by setting cacheDir to `%ASSETS_PATH%/.dynamiccache`