### PR TITLE
Correcting an issue where a new user's security token would be regene…

### DIFF
--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -47,7 +47,7 @@ DynamicCache:
 # Determines which headers should also be cached. X-Include-CSS and other relevant
 # headers can be essential in instructing the front end to include specific
 # resource files
-  cacheHeaders: '/^(X\-)|(Content\-Type)|(Cache\-Control)|(Etag)|(Expires)|(Last\-Modified)|(Location)/i'
+  cacheHeaders: '/^((X\-)|(Content\-Type)|(Cache\-Control)|(Etag)|(Expires)|(Last\-Modified)|(Location))/i'
 # If you wish to override the cache configuration, then change this to another 
 # backend, and initialise a new SS_Cache backend in your _config file
   cacheBackend: 'DynamicCache' 

--- a/code/DynamicCache.php
+++ b/code/DynamicCache.php
@@ -336,7 +336,10 @@ class DynamicCache extends Object
         if (!isset($_SESSION)) {
             Session::start();
         }
-        Session::clear_all(); // Forces the session to be regenerated from $_SESSION
+        // Forces the session to be regenerated from $_SESSION
+        Session::clear_all();
+        // This prevents a new user's security token from being regenerated incorrectly
+        $_SESSION['SecurityID'] = SecurityToken::getSecurityID();
 
         // Get cache and cache details
         $responseHeader = self::config()->responseHeader;


### PR DESCRIPTION
…rated incorrectly, preventing secure form submission.

This is an interesting one that has taken me almost two days of debugging to track down. When using your module out of the box with a fresh install (using 3.2), the security ID for a user is being incorrectly regenerated for a new user. You can confirm this by caching a page that has a form present (similar to https://docs.silverstripe.org/en/3.4/tutorials/forms/), opening a new user session, and then by attempting to submit this form. You should be presented with a "your session has expired, please re-submit this form".

From what I've managed to track down, this is because https://github.com/tractorcow/silverstripe-dynamiccache/blob/master/code/DynamicCache.php#L254 updates the security ID, however subsequent page loads bring in a new security ID, since this isn't written back to the session as expected. The solution here may not be the most elegant, but it prevents this from happening.

In regards to the YAML change, I also noticed a bug where a `Set-Cookie` header was being cached, because it had an `expires=` that was being matched. This would result in a new user pulling in the previous user's security ID, resulting in similar issues to above.

It would be good to hear your thoughts on these, as they've been causing havoc with some forms on a site that I have at the moment. These changes resolve all the issues, and cause the security ID to be generated as expected.