### PR TITLE
Correcting an issue in 3.2 where form errors weren't displaying due t…

### DIFF
--- a/code/DynamicCache.php
+++ b/code/DynamicCache.php
@@ -90,10 +90,10 @@ class DynamicCache extends Object
 
         // If displaying form errors then don't display cached result
         foreach (Session::get_all() as $field => $data) {
-            // Check for session details in the form FormInfo.{$FormName}.errors
+            // Check for session details in the form FormInfo.{$FormName}.errors/FormInfo.{$FormName}.formError
             if ($field === 'FormInfo') {
                 foreach ($data as $formData) {
-                    if (isset($formData['errors'])) {
+                    if (isset($formData['errors']) || isset($formData['formError'])) {
                         return false;
                     }
                 }


### PR DESCRIPTION
…o caching.

I'm not sure why this is `errors` to begin with, is that from a newer/older version? This is where I'm looking.

http://api.silverstripe.org/3.4/source-class-Session.html#574

Either way, it should probably remain for backwards compatibility.