### PR TITLE
fix(IgnoredPages): Comment out / Remove 'UserDefinedForm' from ignoredPages.

### DIFF
--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -52,5 +52,5 @@ DynamicCache:
 # backend, and initialise a new SS_Cache backend in your _config file
   cacheBackend: 'DynamicCache' 
 # Specify page types to skip caching for
-  ignoredPages:
-    - UserDefinedForm
+#  ignoredPages:
+#    - UserDefinedForm

--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -52,5 +52,4 @@ DynamicCache:
 # backend, and initialise a new SS_Cache backend in your _config file
   cacheBackend: 'DynamicCache' 
 # Specify page types to skip caching for
-#  ignoredPages:
-#    - UserDefinedForm
+  ignoredPages: []


### PR DESCRIPTION
fix(IgnoredPages): Comment out / Remove 'UserDefinedForm' from ignoredPages.

We don't want the UDF form to be cached and working around the YML for ignoredPages is annoying.
Do you remember why this was added in?