### PR TITLE
Hit/Miss logging

### DIFF
--- a/_config/dynamiccache.yml
+++ b/_config/dynamiccache.yml
@@ -53,3 +53,5 @@ DynamicCache:
   cacheBackend: 'DynamicCache' 
 # Specify page types to skip caching for
   ignoredPages: []
+# Log Hit/Miss/Skip stats
+  logHitMiss: false

--- a/code/DynamicCache.php
+++ b/code/DynamicCache.php
@@ -289,6 +289,9 @@ class DynamicCache extends Object
         $responseHeader = self::config()->responseHeader;
         if ($responseHeader) {
             header("$responseHeader: hit at " . @date('r'));
+            if (self::config()->logHitMiss) {
+                SS_Log::log("DynamicCache hit", SS_Log::INFO);
+            }
         }
         
         // Substitute security id in forms
@@ -392,6 +395,9 @@ class DynamicCache extends Object
         if (!$enabled) {
             if ($responseHeader) {
                 header("$responseHeader: skipped");
+                if (self::config()->logHitMiss) {
+                    SS_Log::log("DynamicCache skipped", SS_Log::INFO);
+                }
             }
             $this->yieldControl();
             return;
@@ -406,6 +412,9 @@ class DynamicCache extends Object
         // Run this page, caching output and capturing data
         if ($responseHeader) {
             header("$responseHeader: miss at " . @date('r'));
+            if (self::config()->logHitMiss) {
+                SS_Log::log("DynamicCache miss", SS_Log::INFO);
+            }
         }
 
         ob_start();


### PR DESCRIPTION
Adds a new configuration value, logHitMiss (default: false) which when enabled, will use SSLog to record whether DynamicCache was hit, missed or skipped.  Such statistics can be useful in tuning settings and showing justification for the use of DynamicCache.

Addresses issue #45 