### PR TITLE
FIX compatibility with SS 3.7.0

### DIFF
--- a/code/DynamicCache.php
+++ b/code/DynamicCache.php
@@ -393,9 +393,16 @@ class DynamicCache extends Object
         // This prevents a new user's security token from being regenerated incorrectly
         $_SESSION['SecurityID'] = SecurityToken::getSecurityID();
 
+        // Create mock Controller to for Versioned::choose_site_stage()
+        $controllerObj = Injector::inst()->create('Controller');
+        $controllerObj->pushCurrent();
+
         // Set the stage of the website
         // This is normally called in VersionedRequestFilter.
         Versioned::choose_site_stage();
+
+        // Remove mock Controller
+        $controllerObj->popCurrent();
 
         // Get cache and cache details
         $responseHeader = self::config()->responseHeader;


### PR DESCRIPTION
Fixes #73 

Works in PHP 5.6 and 7.2 fixes the problem raised in #73 (Request not found) but there are some other PHP7.2 related issues, these are:

1. `Object` which I've fixed in https://github.com/tractorcow/silverstripe-dynamiccache/compare/master...christopherdarling:feature/php7.2 
2. warning for `session_cache_limiter` which is called after `session_start` in `DynamicCache::run()` I'm yet to fix this though.